### PR TITLE
Use product id as key instead of array index

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,8 +27,8 @@ class Product  extends Component {
 }
 
 const ProductsList = (props) => {
-  const products = props.products.map((product, index) => {
-    return <Product key={index} product={product} onProductChanged={props.onProductChanged} />
+  const products = props.products.map((product) => {
+    return <Product key={product.id} product={product} onProductChanged={props.onProductChanged} />
   });
 
   return (


### PR DESCRIPTION
Hello,

I read your article and took a quick glance at the demo.
Nice improvement with a simple solution which does the trick.

It was just bugging me that it was using the array index as a key (and I have had few encounters where this can go wrong [[info](https://reactjs.org/docs/lists-and-keys.html#keys)]), so I updated it to use the id in order to not encourage readers of the article to use index as keys to react elements.

Cheers,
Goce